### PR TITLE
Move to observer pattern for state change events and go back to initial state setup in constructor

### DIFF
--- a/src/observers.py
+++ b/src/observers.py
@@ -1,0 +1,21 @@
+try:
+    from typing import List
+except ImportError:
+    pass
+
+
+class Observers:
+    def __init__(self) -> None:
+        self._observers: List = []
+
+    def attach(self, observer: object):
+        self._observers.append(observer)
+
+    def detach(self, observer: object):
+        self._observers.remove(observer)
+
+    def notify(self, event_name: str, *params: tuple):
+        for observer in self._observers:
+            handler = getattr(observer, event_name, None)
+            if callable(handler):
+                handler(*params)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,9 +1,28 @@
-from src.state_of_things import State
+from src.state_of_things import State, Thing
+
+
+class NoopState(State):
+    pass
+
+
+class NoopThing(Thing):
+    def __init__(self):
+        super().__init__(NoopState())
 
 
 class TestState:
     def test_name_defaults_to_classname(self):
-        class TestNameDefault(State):
-            pass
+        assert NoopState().name == "NoopState"
 
-        assert TestNameDefault().name == "TestNameDefault"
+    def test_update_does_not_change_state_by_default(self):
+        state = NoopState()
+        thing = NoopThing()
+
+        assert state.update(thing) == state
+
+    def test_enter_and_exit_pass_by_default(self):
+        state = NoopState()
+        thing = NoopThing()
+
+        state.enter(thing)
+        state.exit(thing)

--- a/tests/test_thing.py
+++ b/tests/test_thing.py
@@ -1,0 +1,51 @@
+from src.state_of_things import State, ThingObserver, Thing
+
+
+class TestThing:
+
+    def test_state_change_notifies_attached_observers(self):
+        class StateChangeObserver(ThingObserver):
+            def state_changed(self, old_state: State, new_state: State):
+                self.old_state = old_state
+                self.new_state = new_state
+
+        observers = [StateChangeObserver(), StateChangeObserver()]
+        first_state = State()
+        second_state = State()
+
+        thing = Thing(first_state)
+
+        for observer in observers:
+            thing.observers.attach(observer)
+
+        thing.go_to_state(second_state)
+
+        for observer in observers:
+            assert observer.old_state == first_state
+            assert observer.new_state == second_state
+
+    def test_custom_thing_observers(self):
+        class CustomThingObserver(ThingObserver):
+            def custom_event(self, some_data: str):
+                self.some_data = some_data
+
+        initial_state = State()
+
+        class CustomThingState(State):
+            def enter(self, thing: Thing):
+                thing.observers.notify("custom_event", "test")
+
+        custom_state = CustomThingState()
+
+        thing = Thing(initial_state)
+        observer = CustomThingObserver()
+        thing.observers.attach(observer)
+        observer_without_event = ThingObserver()
+        thing.observers.attach(observer_without_event)
+        thing.go_to_state(custom_state)
+
+        assert observer.some_data == "test"
+
+    # test update of state and previous state
+    # test update enter/exit
+    # test time properties


### PR DESCRIPTION
- moved to Observer pattern for state change and other events, goal is to support interface-like contracts for custom Thing observers
- created ThingObserver as the base observer that receives state change events
- removed logging due to circuitpython not supporting logging package, should happen via an observer
- removed start() approach, instead initial state is passed into constructor. Temporal coupling was more annoying than heavy constructor
- moved Thing internal state behind property accessors
- a few hacky tests for Thing