### PR TITLE
Quest game porting feedback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2020 Diego Elio Pettenò
+#
+# SPDX-License-Identifier: Unlicense
+
+repos:
+  - repo: https://github.com/python/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v0.14.0
+    hooks:
+      - id: reuse
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/pycqa/pylint
+    rev: v2.15.5
+    hooks:
+      - id: pylint
+        name: pylint (library code)
+        types: [python]
+        args:
+          - --disable=consider-using-f-string,duplicate-code
+        exclude: "^(docs/|examples/|tests/|setup.py$)"
+      - id: pylint
+        name: pylint (example code)
+        description: Run pylint rules on "examples/*.py" files
+        types: [python]
+        files: "^examples/"
+        args:
+          - --disable=missing-docstring,invalid-name,consider-using-f-string,duplicate-code
+      - id: pylint
+        name: pylint (test code)
+        description: Run pylint rules on "tests/*.py" files
+        types: [python]
+        files: "^tests/"
+        args:
+          - --disable=missing-docstring,consider-using-f-string,duplicate-code

--- a/tests/test_thing.py
+++ b/tests/test_thing.py
@@ -86,3 +86,5 @@ class TestThing:
     # update - test time properties
     # update - test state staying the same
     # update - test state causing move to another state
+    # time ellapsed and active
+    # add missing pydocs


### PR DESCRIPTION
Do NOT go to initial state in the constructor, switch to it on first update() call if there is no current state
Added thing to state_changed observer so a single observer class can be used by multiple things
Added Thing.name that defaults to class name but can be overridden in constructor