### PR TITLE
Observers is meant to be used outside of Things, make it first class

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,2 @@
 from .state_of_things import *
+from .observers import *

--- a/src/observers.py
+++ b/src/observers.py
@@ -11,7 +11,7 @@ class Observers:
     """
 
     def __init__(self) -> None:
-        self._observers: List = []
+        self.__observers: List = []
 
     def attach(self, observer: object):
         """
@@ -21,7 +21,7 @@ class Observers:
         Args:
             observer (object): the observer to attach.
         """
-        self._observers.append(observer)
+        self.__observers.append(observer)
 
     def detach(self, observer: object):
         """
@@ -31,7 +31,7 @@ class Observers:
         Args:
             observer (object): the observer to detach.
         """
-        self._observers.remove(observer)
+        self.__observers.remove(observer)
 
     def notify(self, event_name: str, *params: object):
         """
@@ -43,7 +43,7 @@ class Observers:
             event_name (str): event that has occurred.
             params (*object): optional event data
         """
-        for observer in self._observers:
+        for observer in self.__observers:
             handler = getattr(observer, event_name, None)
             if callable(handler):
                 handler(*params)

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,0 +1,67 @@
+from src.state_of_things import Observers
+
+
+class CapturingObserver:
+    """Records when a test event is observed."""
+
+    def __init__(self) -> None:
+        self.__captured_params = None
+
+    def test_event(self, *params):
+        self.__captured_params = params
+
+    def assert_notified(self, *params):
+        assert self.__captured_params == params
+
+    def assert_not_notified(self):
+        assert self.__captured_params is None
+
+
+class TestObservers:
+
+    def test_attached_observer_is_notified(self):
+        """
+        When an observer is attached and has a function definition
+        that matches the event name, it should be notified when an
+        event occurs.
+        """
+        observers = Observers()
+
+        test_observer = CapturingObserver()
+        observers.attach(test_observer)
+
+        observers.notify(CapturingObserver.test_event.__name__, 1234, "Hello!", 0.54321)
+
+        test_observer.assert_notified(1234, "Hello!", 0.54321)
+
+    def test_detached_observer_is_not_notified(self):
+        """
+        Observers that are detached should no longer receive event
+        notifications.
+        """
+        observers = Observers()
+
+        test_observer = CapturingObserver()
+        observers.attach(test_observer)
+
+        # detach the attached observer
+        observers.detach(test_observer)
+
+        observers.notify(CapturingObserver.test_event.__name__, 1234, "Hello!", 0.54321)
+
+        test_observer.assert_not_notified()
+
+    def test_notify_skips_observers_without_event_handler(self):
+        """
+        Observers that do not define a function to handle an event
+        should be skipped (and no exception should occur).
+        """
+        observers = Observers()
+
+        test_observer = CapturingObserver()
+        observers.attach(test_observer)
+
+        # this event is not handled by test_observer
+        observers.notify("test_unhandled_event", 1234, "Hello!", 0.54321)
+
+        test_observer.assert_not_notified()

--- a/tests/test_thing_observers.py
+++ b/tests/test_thing_observers.py
@@ -95,44 +95,6 @@ class TestThingObservers:
 
         observer.assert_notified(expected_v1, expected_v2)
 
-    def test_observers_ignore_unhandled_events(self):
-        """
-        Observers that do not define a function matching the event name
-        will not be notified.
-        """
-        # State will notify a custom event when entered
-        custom_state = CustomNotifierState()
-
-        thing = Thing(State())
-        # this observer does not support the custom event
-        observer_without_custom_event = ThingObserver()
-        thing.observers.attach(observer_without_custom_event)
-
-        # trigger the custom event
-        thing.go_to_state(custom_state)
-
-        # the observer should not be invoked
-        assert not hasattr(observer_without_custom_event, "notified_v1")
-        assert not hasattr(observer_without_custom_event, "notified_v2")
-
-    def test_detached_observers_are_not_notified(self):
-        """
-        Detached observers no longer receive notification of events.
-        """
-        thing = Thing(State())
-
-        observer = StateChangeObserver()
-        thing.observers.attach(observer)
-
-        # detach the observer before a state change
-        thing.observers.detach(observer)
-
-        # change the state
-        thing.go_to_state(State())
-
-        # the observer was detached so should not see the state change
-        observer.assert_not_notified()
-
     def test_going_to_current_state_does_not_notify_change_state(self):
         """
         When changing States, if the new State is the same as the
@@ -148,3 +110,12 @@ class TestThingObservers:
         thing.go_to_state(initial_state)
 
         observer.assert_not_notified()
+
+    def test_thing_observer_does_nothing_by_default(self):
+        """
+        By default, ThingObserver will do nothing when state changes
+        are received (as opposed to throwing an exception).
+        """
+        observer = ThingObserver()
+
+        observer.state_changed(Thing(State()), State(), State())


### PR DESCRIPTION
Imported in package by default and wrote tests
De-dupe test_observers and test_thing_observers