### PR TITLE
Hide Thing.go_to_state function

### DIFF
--- a/src/state_of_things/state_of_things.py
+++ b/src/state_of_things/state_of_things.py
@@ -107,10 +107,10 @@ class Thing:
         self.__time_ellapsed: float = 0
         self.__time_active: float = 0
 
-    def go_to_state(self, state: State):
+    def __go_to_state(self, state: State):
         """
-        Manually change the Thing to a new State. Notifies all observers
-        of the State change if moving from a previous State.
+        Change the Thing to a new State. Notifies all observers of the
+        State change if moving from a previous State.
 
         Args:
             state (State): the target State for this Thing
@@ -151,7 +151,7 @@ class Thing:
         """
         # if the Thing is not in it's initial State, change to it
         if self.__current_state is None:
-            self.go_to_state(self.__initial_state)
+            self.__go_to_state(self.__initial_state)
 
         # update time tracking properties
         now = time.monotonic()
@@ -162,7 +162,7 @@ class Thing:
         # update the current State
         next_state = self.__current_state.update(self)
         if next_state != self.__current_state:
-            self.go_to_state(next_state)
+            self.__go_to_state(next_state)
 
     @property
     def name(self) -> str:

--- a/tests/fixtures/observer.py
+++ b/tests/fixtures/observer.py
@@ -1,0 +1,69 @@
+from state_of_things import State, Thing, ThingObserver
+
+
+class CapturingObserver:
+    """Records when a test event is observed."""
+
+    def __init__(self) -> None:
+        self.__captured_params = None
+
+    def test_event(self, *params):
+        self.__captured_params = params
+
+    def assert_notified(self, *params):
+        assert self.__captured_params == params
+
+    def assert_not_notified(self):
+        assert self.__captured_params is None
+
+
+class StateChangeObserver(ThingObserver):
+    """Records when a state change is observed."""
+
+    def __init__(self) -> None:
+        self.__thing: Thing = None
+        self.__old_state: State = None
+        self.__new_state: State = None
+
+    def state_changed(self, thing: Thing, old_state: State, new_state: State):
+        self.__thing = thing
+        self.__old_state = old_state
+        self.__new_state = new_state
+
+    def assert_notified(self, thing: Thing, old_state: State, new_state: State):
+        assert self.__thing == thing
+        assert self.__old_state == old_state
+        assert self.__new_state == new_state
+
+    def assert_not_notified(self):
+        assert self.__thing is None
+        assert self.__old_state is None
+        assert self.__new_state is None
+
+
+class CustomThingObserver(ThingObserver):
+    """Records when a custom event is observed."""
+
+    def __init__(self) -> None:
+        self.__notified_v1: str = None
+        self.__notified_v2: int = None
+
+    def custom_event(self, v1: str, v2: int):
+        self.__notified_v1 = v1
+        self.__notified_v2 = v2
+
+    def assert_notified(self, expected_v1: str, expected_v2: int):
+        assert self.__notified_v1 == expected_v1
+        assert self.__notified_v2 == expected_v2
+
+
+class CustomNotifierState(State):
+    """Notifies a custom event when entered."""
+
+    EVENT_NAME = CustomThingObserver.custom_event.__name__
+
+    def __init__(self, *params) -> None:
+        self.params = params
+
+    def enter(self, thing: Thing):
+        thing.observers.notify(self.EVENT_NAME, *self.params)

--- a/tests/fixtures/state.py
+++ b/tests/fixtures/state.py
@@ -1,0 +1,50 @@
+from src.state_of_things import State, Thing
+
+
+class EnterExitTrackingState(State):
+    """Records when a State is entered or exited."""
+
+    def __init__(self) -> None:
+        self.__entered_thing: Thing = None
+        self.__exited_thing: Thing = None
+
+    def enter(self, thing: Thing):
+        self.__entered_thing = thing
+
+    def exit(self, thing: Thing):
+        self.__exited_thing = thing
+
+    def assert_entered(self, thing: Thing):
+        assert self.__entered_thing == thing
+
+    def assert_not_entered(self):
+        assert self.__entered_thing is None
+
+    def assert_exited(self, thing: Thing):
+        assert self.__exited_thing == thing
+
+    def assert_not_exited(self):
+        assert self.__exited_thing is None
+
+
+class ImmediateChangeState(EnterExitTrackingState):
+    """State that immediately changes to a next State."""
+
+    def __init__(self, next_state: State) -> None:
+        """State that changes into a next State on first update.
+
+        Args:
+            next_state (State): the State to change into.
+        """
+        super().__init__()
+        self.__next_state = next_state
+
+    def update(self, thing: Thing) -> State:
+        return self.__next_state
+
+
+class NeverChangeState(EnterExitTrackingState):
+    """State that never changes to another State."""
+
+    def update(self, thing: Thing) -> State:
+        return self

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,20 +1,5 @@
 from src.state_of_things import Observers
-
-
-class CapturingObserver:
-    """Records when a test event is observed."""
-
-    def __init__(self) -> None:
-        self.__captured_params = None
-
-    def test_event(self, *params):
-        self.__captured_params = params
-
-    def assert_notified(self, *params):
-        assert self.__captured_params == params
-
-    def assert_not_notified(self):
-        assert self.__captured_params is None
+from .fixtures.observer import *
 
 
 class TestObservers:

--- a/tests/test_thing.py
+++ b/tests/test_thing.py
@@ -1,31 +1,6 @@
 import pytest
-from src.state_of_things import State, Thing
-
-
-class EnterExitTrackingState(State):
-    """Records when a State is entered or exited."""
-
-    def __init__(self) -> None:
-        self.__entered_thing: Thing = None
-        self.__exited_thing: Thing = None
-
-    def enter(self, thing: Thing):
-        self.__entered_thing = thing
-
-    def exit(self, thing: Thing):
-        self.__exited_thing = thing
-
-    def assert_entered(self, thing: Thing):
-        assert self.__entered_thing == thing
-
-    def assert_not_entered(self):
-        assert self.__entered_thing is None
-
-    def assert_exited(self, thing: Thing):
-        assert self.__exited_thing == thing
-
-    def assert_not_exited(self):
-        assert self.__exited_thing is None
+from src.state_of_things import Thing
+from .fixtures.state import *
 
 
 class TestThing:
@@ -57,14 +32,13 @@ class TestThing:
         When changing States, the current State should exit before
         the new State is entered.
         """
-        initial_state = EnterExitTrackingState()
+
         new_state = EnterExitTrackingState()
+        initial_state = ImmediateChangeState(next_state=new_state)
 
         thing = Thing(initial_state)
-        # go to initial state
+        # go to initial state, which then changes to the new state
         thing.update()
-
-        thing.go_to_state(new_state)
 
         assert thing.current_state == new_state
         assert thing.previous_state == initial_state
@@ -78,12 +52,12 @@ class TestThing:
         When changing States, if the new State is the same as the
         current State then do not enter or exit States.
         """
-        initial_state = EnterExitTrackingState()
+        initial_state = NeverChangeState()
 
         thing = Thing(initial_state)
 
-        # go to the current State (should not trigger a change)
-        thing.go_to_state(initial_state)
+        # go to the initial State (should not trigger a change)
+        thing.update()
 
         assert thing.current_state == initial_state
         assert thing.previous_state is None

--- a/tests/test_thing_observers.py
+++ b/tests/test_thing_observers.py
@@ -1,56 +1,6 @@
 from src.state_of_things import State, Thing, ThingObserver
-
-
-class StateChangeObserver(ThingObserver):
-    """Records when a state change is observed."""
-
-    def __init__(self) -> None:
-        self.__thing: Thing = None
-        self.__old_state: State = None
-        self.__new_state: State = None
-
-    def state_changed(self, thing: Thing, old_state: State, new_state: State):
-        self.__thing = thing
-        self.__old_state = old_state
-        self.__new_state = new_state
-
-    def assert_notified(self, thing: Thing, old_state: State, new_state: State):
-        assert self.__thing == thing
-        assert self.__old_state == old_state
-        assert self.__new_state == new_state
-
-    def assert_not_notified(self):
-        assert self.__thing is None
-        assert self.__old_state is None
-        assert self.__new_state is None
-
-
-class CustomThingObserver(ThingObserver):
-    """Records when a custom event is observed."""
-
-    def __init__(self) -> None:
-        self.__notified_v1: str = None
-        self.__notified_v2: int = None
-
-    def custom_event(self, v1: str, v2: int):
-        self.__notified_v1 = v1
-        self.__notified_v2 = v2
-
-    def assert_notified(self, expected_v1: str, expected_v2: int):
-        assert self.__notified_v1 == expected_v1
-        assert self.__notified_v2 == expected_v2
-
-
-class CustomNotifierState(State):
-    """Notifies a custom event when entered."""
-
-    EVENT_NAME = CustomThingObserver.custom_event.__name__
-
-    def __init__(self, *params) -> None:
-        self.params = params
-
-    def enter(self, thing: Thing):
-        thing.observers.notify(self.EVENT_NAME, *self.params)
+from .fixtures.observer import *
+from .fixtures.state import *
 
 
 class TestThingObservers:
@@ -60,17 +10,16 @@ class TestThingObservers:
         notification of state changes with old and new States.
         """
         observers = [StateChangeObserver(), StateChangeObserver()]
-        initial_state = State()
+
         new_state = State()
+        initial_state = ImmediateChangeState(next_state=new_state)
 
         thing = Thing(initial_state)
-        # go to intial state
-        thing.update()
-
         for observer in observers:
             thing.observers.attach(observer)
 
-        thing.go_to_state(new_state)
+        # go to initial state, which will change to new_state
+        thing.update()
 
         for observer in observers:
             observer.assert_notified(thing, initial_state, new_state)
@@ -86,12 +35,12 @@ class TestThingObservers:
         # State will notify a custom event when entered
         custom_state = CustomNotifierState(expected_v1, expected_v2)
 
-        thing = Thing(State())
+        thing = Thing(custom_state)
         observer = CustomThingObserver()
         thing.observers.attach(observer)
 
-        # trigger the custom event
-        thing.go_to_state(custom_state)
+        # trigger the custom event by going to the initial state
+        thing.update()
 
         observer.assert_notified(expected_v1, expected_v2)
 
@@ -100,14 +49,17 @@ class TestThingObservers:
         When changing States, if the new State is the same as the
         current State then do not notify a state change.
         """
-        initial_state = State()
+        initial_state = NeverChangeState()
 
         thing = Thing(initial_state)
+        # go to the initial state
+        thing.update()
+
         observer = StateChangeObserver()
         thing.observers.attach(observer)
 
-        # go to the current State (should not trigger a change)
-        thing.go_to_state(initial_state)
+        # stay in the current State (should not trigger a change)
+        thing.update()
 
         observer.assert_not_notified()
 


### PR DESCRIPTION
After drafting documentation that said go_to_state should never be invoked outside of a Thing, I realized I should just make it private instead. Some tests were using go_to_state, so I needed to instead use the test fixtures. I moved the test fixtures out of individual test scripts into a fixtures modules so that they can be shared by multiple test scripts.

Note: I did not use the pytest.fixture annotation. I ported all of the tests to it and it made the tests harder to understand while requiring boilerplate fixture functions for each test class. It seemed easier to command-click directly on a class referenced inside a test instead of following the indirect fixture parameter route back to the fixture.