### PR TITLE
Fix deprecated readthedocs projects

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,3 +17,7 @@ python:
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt
+
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/